### PR TITLE
Fix TypeError: sort() takes no positional arguments.

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -471,7 +471,7 @@ class Implosion_1(Spell):
                     if self.caster.mp[0] >= 15:
                         self.affected.append(monster)
 
-            self.affected.sort(lambda x, y: cmp(y.maxhp, x.maxhp))
+            self.affected.sort(key=lambda x: x.maxhp)
 
             if len(self.affected):
                 self.affected = self.affected[:1]


### PR DESCRIPTION
This error happens when using Nyx's Implosion spell (<kbd>D</kbd><kbd>W</kbd>)

In Python 3, `sort()` takes a sorting function as a keyword argument named `key` rather than a plain positional argument (as in Python 2).

```
Traceback (most recent call last):
  File "ardentryst.py", line 4733, in <module>
    main()
  File "ardentryst.py", line 4434, in main
    handle_game(Game, True)
  File "ardentryst.py", line 3095, in handle_game
    PLAYLOCALS)#, "DEMO.dem")
  File "play_level.py", line 2892, in playlevel
    PLAYER.magic_tick()
  File "play_level.py", line 5361, in magic_tick
    spell.tick(LEVEL, [x for x in Monsters if not x.ghost], self, RAIN_HEAVINESS)
  File "magic.py", line 90, in tick
    self.stick()
  File "magic.py", line 474, in stick
    self.affected.sort(lambda x, y: cmp(y.maxhp, x.maxhp))
  TypeError: sort() takes no positional arguments
```

