### PR TITLE
Python3: Fix IndexError when hovering mouse under Quit button. 

### DIFF
--- a/ardentryst.py
+++ b/ardentryst.py
@@ -4373,8 +4373,8 @@ def main():
                     mcurs = list(pygame.mouse.get_pos())
                     #check if on menu items
                     if 150 > mcurs[0] > 0 and 230 + 29 * (len(menu_items)) > mcurs[1] > 230:
-                        if activeitem[menu_items[int(round((mcurs[1]-230) / 29))]]:
-                            menu_select = int(round((mcurs[1]-230) / 29))
+                        if activeitem[menu_items[int((mcurs[1]-230) / 29)]]:
+                            menu_select = int((mcurs[1]-230) / 29)
                             handy = 218 + menu_select * 29
                             if menu_select >= len(menu_items): menu_select = -1
 

--- a/magic.py
+++ b/magic.py
@@ -27,7 +27,7 @@ def ground_at(LEVEL, x, f=False):
     ysense = 479
     sensing = True
     while sensing:
-        sensetile = LEVEL.map[x/40][ysense/40]
+        sensetile = LEVEL.map[x//40][ysense//40]
         if not sensetile or "NONE" in sensetile.collidetype: break
         if sensetile.collidetype == "RIGHT_INCLINATION":
             if x%40 < 40-(ysense%40):


### PR DESCRIPTION
The game crashes with an `IndexError: list index out of range` if I move the mouse cursor to where the menu item description is displayed (just below the Quit button) on the main menu.